### PR TITLE
Make chordified chords show up over text in Firefox; other HTML fixes

### DIFF
--- a/toucansam/toucansam/templates/set_list.html
+++ b/toucansam/toucansam/templates/set_list.html
@@ -46,13 +46,13 @@
     }
 
 </style>
+<link rel="stylesheet" href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.9.0/themes/base/jquery-ui.css" type="text/css">
 {% endblock %}
 
 {% block extra_scripts %}
 <script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.9.2/jquery-ui.min.js" type="text/javascript"></script>
-<link rel="stylesheet" href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.9.0/themes/base/jquery-ui.css" type="text/css" media="all" />
 
-<script type="text/javascript" charset="utf-8">
+<script type="text/javascript">
     $(function() {
 
         var stretch_lists = function() {
@@ -154,7 +154,7 @@
         <table id="song_list" class="table table-bordered">
             <thead>
                 <tr>
-                    <th data-sort="string-ins" data-sort="string-ins">Title</th>
+                    <th data-sort="string-ins">Title</th>
                     <th data-sort="string-ins" class="set_list_only">Cheat Sheet</th>
                     <th data-sort="string-ins" class="catalog_only">Artist</th>
                     <th data-sort="string-ins" class="catalog_only">Key</th>
@@ -194,7 +194,7 @@
             <a href="{% url "print_songs_in" set_list_id %}" class="btn btn-info float_right" target="_blank">Print all songs</a>
             {% endif %}
         </h2>
-        <form id="save_set_list" action="" method="post">
+        <form id="save_set_list" method="post">
             <div class="randocolor">
             {% if gig %}
                 <h2>{{ gig.name }}</h2>

--- a/toucansam/toucansam/templates/shared_base.html
+++ b/toucansam/toucansam/templates/shared_base.html
@@ -1,5 +1,4 @@
-{% load toucan %}
-<!DOCTYPE html>
+{% load toucan %}<!DOCTYPE html>
 <html>
     <head>
         <title>{% block page_title %}Have a very ukule-ly day{% endblock %}</title>

--- a/toucansam/toucansam/templates/song.html
+++ b/toucansam/toucansam/templates/song.html
@@ -77,6 +77,7 @@
         width: 0;
         height: 2.5em;
         display: inline-block;
+        vertical-align: text-bottom;
         overflow: visible;
         color: #1e90ff;
         font-weight: bold;
@@ -214,7 +215,7 @@ $(function(){
         {{ song.title }}
 
         <span id="time">{{ song.run_time }}</span>
-        <a href="{% url 'print_song' song_id=song.id %}" class="btn btn-info float_right" target="_new">Print</a>
+        <a href="{% url 'print_song' song_id=song.id %}" class="btn btn-info float_right" target="_blank">Print</a>
 
         {% if user.is_staff %}
         <form id="update_time" method="post"> {% csrf_token %}
@@ -248,7 +249,7 @@ $(function(){
     </h4>
     {% if song.youtube_video_id %}
     <div id="embedded">
-        <iframe class="youtube-player" type="text/html" width="640" height="385" src="http://www.youtube.com/embed/{{ song.youtube_video_id }}" allowfullscreen frameborder="0">
+        <iframe class="youtube-player" width="640" height="385" src="http://www.youtube.com/embed/{{ song.youtube_video_id }}" allowfullscreen style="border:0;">
         </iframe>
     </div>
     {% endif %}
@@ -256,17 +257,19 @@ $(function(){
     {% if song.cheat_sheet %}
         <div id="cheatsheet">
             <div id="cheatsheet-inner" class="pinnable" >
+            <form id="save_time" class="float_right" method="post"> {% csrf_token %}
                 <h3 class="randocolor">
                     cheat sheet: {{ song.cheat_sheet }}
 {#                    <a href="#" class="pin btn btn-info float_right">Unpin</a>#}
 {#                    <a href="#" id="play" class="btn btn-info float_right">Play</a>#}
                     <span id="playtime" class="float_right">0:00</span>
-                    <form id="save_time" class="float_right" method="post"> {% csrf_token %}
-                        <input type="hidden" name="update_time" value="yup"/>
-                        <input type="hidden" name="runtime" value=""/>
-                        <input type="submit" class="btn btn-info" value="Save Time"/>
-                    </form>
-                </h3>
+                    
+                    <input type="hidden" name="update_time" value="yup"/>
+                    <input type="hidden" name="runtime" value=""/>
+                    <input type="submit" class="btn btn-info" value="Save Time"/>
+                   
+                </h3> 
+            </form>
             </div>
         </div>
     {% endif %}

--- a/toucansam/toucansam/templates/song_list.html
+++ b/toucansam/toucansam/templates/song_list.html
@@ -46,7 +46,7 @@
 {% block extra_scripts %}
 <script src="{{ STATIC_URL }}js/jquery.dataTables.min.js"></script>
 
-<script type="text/javascript" charset="utf-8">
+<script type="text/javascript">
     $(function() {
         $('#song_list').dataTable({
             bPaginate:false,
@@ -147,8 +147,8 @@
                                  {% endif %}
                                  data-difficulty="{{ i }}"
                                  data-song-url="{% url 'song' song.id %}"
-                                 class="uke u{{ i }} {% if i <= song.difficulty %}on{% endif %}">
-                             </img>
+                                 class="uke u{{ i }} {% if i <= song.difficulty %}on{% endif %}"
+                                 alt="difficulty {{ song.difficulty }}">
                         {% endfor %}
                     </td>
                     <td>


### PR DESCRIPTION
Example:
![firefox](https://cloud.githubusercontent.com/assets/3779809/6243695/19fa3496-b6fc-11e4-9172-f345b24bbb06.png)
